### PR TITLE
Added suppression of CMake warnings on finding Python packages

### DIFF
--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi_msgs)
 
+# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
+# are removed."
+if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)
+  cmake_policy(SET CMP0148 OLD)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/rosapi_msgs/CMakeLists.txt
+++ b/rosapi_msgs/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosapi_msgs)
 
-# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# CMake >= 3.27 + ROS2 Humble:
+# Set CMake policy CMP0148 on finding Python to avoid:
 # "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
 # are removed."
 if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_msgs)
 
+# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
+# are removed."
+if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)
+  cmake_policy(SET CMP0148 OLD)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/rosbridge_msgs/CMakeLists.txt
+++ b/rosbridge_msgs/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_msgs)
 
-# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# CMake >= 3.27 + ROS2 Humble:
+# Set CMake policy CMP0148 on finding Python to avoid:
 # "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
 # are removed."
 if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_server)
 
-# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# CMake >= 3.27 + ROS2 Humble:
+# Set CMake policy CMP0148 on finding Python to avoid:
 # "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
 # are removed."
 if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)

--- a/rosbridge_server/CMakeLists.txt
+++ b/rosbridge_server/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_server)
 
+# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
+# are removed."
+if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)
+  cmake_policy(SET CMP0148 OLD)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_test_msgs)
 
-# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# CMake >= 3.27 + ROS2 Humble:
+# Set CMake policy CMP0148 on finding Python to avoid:
 # "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
 # are removed."
 if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)

--- a/rosbridge_test_msgs/CMakeLists.txt
+++ b/rosbridge_test_msgs/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbridge_test_msgs)
 
+# CMake >= 3.27: Set CMake policy CMP0148 on finding Python to avoid:
+# "Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
+# are removed."
+if(CMAKE_MINOR_VERSION VERSION_GREATER_EQUAL 27)
+  cmake_policy(SET CMP0148 OLD)
+endif()
+
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(builtin_interfaces REQUIRED)


### PR DESCRIPTION
The warnings are generated via `rosidl_generate_interfaces` for CMake >= 3.27.
This currently occurs with ROS2 Humble. Note that this code can/must be removed when rosidl is updated with the new CMP0148 policy.

Example console output showing the warnings:
```
CMake Warning (dev) at /opt/ros/humble/share/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake:20 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /opt/ros/humble/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:16 (rosidl_generate_interfaces)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /opt/ros/humble/share/python_cmake_module/cmake/Modules/FindPythonExtra.cmake:52 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /opt/ros/humble/share/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake:23 (find_package)
  /opt/ros/humble/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:16 (rosidl_generate_interfaces)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /opt/ros/humble/share/python_cmake_module/cmake/Modules/FindPythonExtra.cmake:140 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /opt/ros/humble/share/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake:23 (find_package)
  /opt/ros/humble/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:16 (rosidl_generate_interfaces)
This warning is for project developers.  Use -Wno-dev to suppress it.
```